### PR TITLE
[Feature] Tournament name

### DIFF
--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -70,7 +70,8 @@ document.querySelector('#team-form').addEventListener('submit', (e) => {
       }
     },
     bestOf: parseInt(document.querySelector('#best-of').value),
-    roundOf: parseInt(document.querySelector('#round-of').value)
+    roundOf: parseInt(document.querySelector('#round-of').value),
+    tournamentName: document.querySelector('#tournament-name').value
   })
 
   addTeam(blueTeam)
@@ -124,6 +125,7 @@ function unset() {
   document.querySelector('#red-team-coach').value = ''
   document.querySelector('#best-of').value = 1
   document.querySelector('#round-of').value = 2
+  document.querySelector('#tournament-name').value = ''
 }
 
 async function initUi() {
@@ -217,6 +219,7 @@ async function displayData(data) {
 
   document.querySelector('#best-of').value = data.bestOf
   document.querySelector('#round-of').value = data.roundOf
+  document.querySelector('#tournament-name').value = data.tournamentName
 }
 
 window.LPTE.onready(() => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -145,8 +145,8 @@
           <option value="512">ROUND OF 512</option>
           <option value="1024">ROUND OF 1024</option>
           <option value="2048">ROUND OF 2048</option>
-          <option value="2048">GRAND FINAL 1</option>
-          <option value="2048">GRAND FINAL 2</option>
+          <option value="0">UPPER BRACKET FINAL</option>
+          <option value="1">LOWER BRACKET FINAL</option>
         </select>
       </div>
     </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -67,6 +67,17 @@
 
   <datalist id="teams"></datalist>
 
+  <div class="form-group" style="flex-grow: 1">
+    <label for="tournament-name">Tournament Name</label>
+    <input
+      type="text"
+      placeholder="Tournament Name"
+      id="tournament-name"
+      required
+      class="form-control"
+    />
+  </div>
+
   <div style="display: flex; width: 100%">
     <div id="blue-team" style="display: flex; flex-grow: 1">
       <div class="form-group" style="flex-grow: 1">

--- a/plugin.ts
+++ b/plugin.ts
@@ -73,7 +73,6 @@ module.exports = async (ctx: PluginContext) => {
   })
 
   ctx.LPTE.on(namespace, 'set', async (e: any) => {
-    console.log(e, gfxState)
     if (
       isDeepStrictEqual(gfxState.teams, e.teams) &&
       gfxState.bestOf == e.bestOf &&

--- a/plugin.ts
+++ b/plugin.ts
@@ -7,7 +7,8 @@ const initialState: GfxState = {
   state: 'NO_MATCH',
   teams: {},
   bestOf: 1,
-  roundOf: 2
+  roundOf: 2,
+  tournamentName: ''
 }
 
 module.exports = async (ctx: PluginContext) => {
@@ -42,7 +43,8 @@ module.exports = async (ctx: PluginContext) => {
       state: gfxState.state,
       teams: gfxState.teams,
       bestOf: gfxState.bestOf,
-      roundOf: gfxState.roundOf
+      roundOf: gfxState.roundOf,
+      tournamentName: gfxState.tournamentName
     })
   })
 
@@ -71,10 +73,12 @@ module.exports = async (ctx: PluginContext) => {
   })
 
   ctx.LPTE.on(namespace, 'set', async (e: any) => {
+    console.log(e, gfxState)
     if (
       isDeepStrictEqual(gfxState.teams, e.teams) &&
       gfxState.bestOf == e.bestOf &&
-      gfxState.roundOf == e.roundOf
+      gfxState.roundOf == e.roundOf &&
+      gfxState.tournamentName == e.tournamentName
     )
       return
 
@@ -96,7 +100,8 @@ module.exports = async (ctx: PluginContext) => {
             redTeam: e.teams.blueTeam
           },
           bestOf: e.bestOf,
-          roundOf: e.roundOf
+          roundOf: e.roundOf,
+          tournamentName: e.tournamentName
         }
       })
     } else if (
@@ -117,7 +122,8 @@ module.exports = async (ctx: PluginContext) => {
             redTeam: e.teams.redTeam
           },
           bestOf: e.bestOf,
-          roundOf: e.roundOf
+          roundOf: e.roundOf,
+          tournamentName: e.tournamentName
         }
       })
     } else {
@@ -135,6 +141,7 @@ module.exports = async (ctx: PluginContext) => {
           },
           bestOf: e.bestOf,
           roundOf: e.roundOf,
+          tournamentName: e.tournamentName,
           date: new Date().getTime()
         }
       })
@@ -149,6 +156,7 @@ module.exports = async (ctx: PluginContext) => {
     gfxState.teams = e.teams
     gfxState.bestOf = e.bestOf
     gfxState.roundOf = e.roundOf
+    gfxState.tournamentName = e.tournamentName
 
     ctx.LPTE.emit({
       meta: {
@@ -159,7 +167,8 @@ module.exports = async (ctx: PluginContext) => {
       state: gfxState.state,
       teams: gfxState.teams,
       bestOf: gfxState.bestOf,
-      roundOf: gfxState.roundOf
+      roundOf: gfxState.roundOf,
+      tournamentName: gfxState.tournamentName
     })
   })
 
@@ -181,7 +190,8 @@ module.exports = async (ctx: PluginContext) => {
       state: gfxState.state,
       teams: gfxState.teams,
       bestOf: gfxState.bestOf,
-      roundOf: gfxState.roundOf
+      roundOf: gfxState.roundOf,
+      tournamentName: gfxState.tournamentName
     })
   })
 
@@ -190,7 +200,8 @@ module.exports = async (ctx: PluginContext) => {
       state: 'NO_MATCH',
       teams: {},
       bestOf: 1,
-      roundOf: 2
+      roundOf: 2,
+      tournamentName: ''
     }
 
     ctx.LPTE.emit({
@@ -202,7 +213,8 @@ module.exports = async (ctx: PluginContext) => {
       state: gfxState.state,
       teams: gfxState.teams,
       bestOf: gfxState.bestOf,
-      roundOf: gfxState.roundOf
+      roundOf: gfxState.roundOf,
+      tournamentName: gfxState.tournamentName
     })
   })
 
@@ -221,7 +233,8 @@ module.exports = async (ctx: PluginContext) => {
       state: 'NO_MATCH',
       teams: {},
       bestOf: 1,
-      roundOf: 2
+      roundOf: 2,
+      tournamentName: ''
     }
 
     ctx.LPTE.emit({
@@ -233,7 +246,8 @@ module.exports = async (ctx: PluginContext) => {
       state: gfxState.state,
       teams: gfxState.teams,
       bestOf: gfxState.bestOf,
-      roundOf: gfxState.roundOf
+      roundOf: gfxState.roundOf,
+      tournamentName: gfxState.tournamentName
     })
   })
 
@@ -419,7 +433,8 @@ module.exports = async (ctx: PluginContext) => {
     state: gfxState.state,
     teams: gfxState.teams,
     bestOf: gfxState.bestOf,
-    roundOf: gfxState.roundOf
+    roundOf: gfxState.roundOf,
+    tournamentName: gfxState.tournamentName
   })
 
   // Emit event that we're ready to operate

--- a/types/GfxState.d.ts
+++ b/types/GfxState.d.ts
@@ -8,5 +8,6 @@ export interface GfxState {
   }
   bestOf: number
   id?: any
-  roundOf: 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048
+  roundOf: 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048,
+  tournamentName: string
 }

--- a/types/GfxState.d.ts
+++ b/types/GfxState.d.ts
@@ -8,6 +8,6 @@ export interface GfxState {
   }
   bestOf: number
   id?: any
-  roundOf: 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048,
+  roundOf: 0 | 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048,
   tournamentName: string
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
There is no place to insert tournament/match name.

**Describe the solution you'd like**
Added a field to store the information in the database.

**Describe alternatives you've considered**
Don't know any

**Additional context**
I also updated `GRAND FINAL 1` and `GRAND FINAL 2` dropdown values (they were both 2048) and changed names to `LOWER BRACKET FINAL` and `UPPER BRACKET FINAL`. Screenshot 2 below

![image](https://github.com/rcv-prod-toolkit/module-teams/assets/46965900/a3e5ba8d-9afe-4735-9be3-88b29ed70763)

![image](https://github.com/rcv-prod-toolkit/module-teams/assets/46965900/bc7fd010-d720-4133-a820-6efabdb6037e)
